### PR TITLE
Lantana v2.2.0

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 __copyright__    = 'Copyright (C) 2022 WSOFT.'
-__version__      = '2.1.0'
+__version__      = '2.2.0'
 __license__      = 'MIT'
 __author__       = 'WSOFT'
 __author_email__ = 'info@wsoft.ws'
-__url__          = 'http://wsoft-project.github.io/lantana/'
+__url__          = 'https://lantana.wsoft.ws/'

--- a/lantana/base.html
+++ b/lantana/base.html
@@ -63,6 +63,9 @@
   {% for path in config.extra_css %}
     <link href="{{ path|url }}" rel="stylesheet">
   {% endfor %}
+  {% for path2 in page.extra_css %}
+    <link href="{{ path2|url }}" rel="stylesheet">
+  {% endfor %}
   
   <script async>var base_url = '{{ base_url }}';</script>
   <script src="https://code.jquery.com/jquery-3.6.1.slim.min.js" integrity="sha256-w8CvhFs7iHNVUtnSP0YKEg00p9Ih13rlL9zGqvLdePA=" crossorigin="anonymous"></script>
@@ -162,6 +165,9 @@
       {% endif %}
       {% for path in config.extra_javascript %}
     <script async src="{{ path|url }}"></script>
+      {% endfor %}
+      {% for path2 in page.extra_javascript %}
+    <script async src="{{ path2|url }}"></script>
       {% endfor %}
       <script>
         afterload();

--- a/lantana/main.html
+++ b/lantana/main.html
@@ -27,7 +27,11 @@
     {% endif %}
     {% endif %}
     <div class="col-12 col-md-8 print-main">
-    <h1>{{ page.title }}</h1>
+      {% if page and page.meta.long_title %}
+      <h1>{{ page.meta.long_title }}</h1>
+      {% else %}
+      <h1>{{ page.title }}</h1>
+      {% endif %}
     <nav aria-label="breadcrumb">
       <ol class="breadcrumb">
         <li class="breadcrumb-item active" aria-current="page">{{ config.site_name }}</li>

--- a/lantana/version.json
+++ b/lantana/version.json
@@ -1,6 +1,6 @@
 {
     "Product" : "Lantana",
     "CodeName" : "tapioca",
-    "Version" : "2.1.0",
-    "FullName" : "WSOFT Lantana v2.1.0(tapioca)"
+    "Version" : "2.2.0",
+    "FullName" : "WSOFT Lantana v2.2.0(tapioca)"
 }

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-VERSION = '2.1.0'
+VERSION = '2.2.0'
 
 setup(
     name="lantana",


### PR DESCRIPTION
# 概要
- 記事ごとにCSSやJavaScriptを適用できる、`page.meta.extra_css`と`page.meta.extra_javascript`を読み込むようになりました
- 長いタイトルを表示することを避けるため、`page.meta.long_title`を別に指定できるようになりました